### PR TITLE
Update in models.py resize_profile_image

### DIFF
--- a/project/core/settings.py
+++ b/project/core/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = (
     "notification",
     "debug_toolbar",
     "django_browser_reload",
+    "imagekit",
 )
 
 MIDDLEWARE = [


### PR DESCRIPTION
This addresses a TODO that wanted to shorten the resize_profile_image function within the accounts/models.py file. It uses django-imagekit to dynamically create a profile image thumbnail upon request from the program sourcing the image from the stored profile_image that is either initialized on account creation or updated later on. It removes the need to repeat code for both the profile_image attribute and thumbnail attribute.
